### PR TITLE
✨ feat: support midjourney-proxy API secret

### DIFF
--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "يرجى الرجوع إلى <1>midjourney-proxy</1> ونشر الخدمة الخادمية لاستخدامها",
-      "title": "عنوان وكيل Midjourney API"
+      "apiSecret": {
+        "title": "سر وكيل Midjourney API"
+      },
+      "baseUrl": {
+        "title": "عنوان وكيل Midjourney API"
+      },
+      "description": "يرجى الرجوع إلى <1>midjourney-proxy</1> ونشر الخدمة الخادمية لاستخدامها"
     },
     "modalTitle": "الإعدادات",
     "save": "حفظ"

--- a/locales/de-DE/common.json
+++ b/locales/de-DE/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Bitte installieren Sie den <1>midjourney-proxy</1>-Server und verwenden Sie ihn",
-      "title": "Midjourney API-Proxy-Adresse"
+      "apiSecret": {
+        "title": "Midjourney API Proxy Secret"
+      },
+      "baseUrl": {
+        "title": "Midjourney API Proxy-URL"
+      },
+      "description": "Bitte installieren Sie den <1>midjourney-proxy</1>-Server und verwenden Sie ihn"
     },
     "modalTitle": "Einstellungen",
     "save": "Speichern"

--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -35,8 +35,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Please refer to <1>midjourney-proxy</1> for deploying the server and then use",
-      "title": "Midjourney API Proxy Address"
+      "baseUrl": {
+        "title": "Midjourney API Proxy Address"
+      },
+      "apiSecret": {
+        "title": "Midjourney API Proxy Secret"
+      },
+      "description": "Please refer to <1>midjourney-proxy</1> for deploying the server and then use"
     },
     "modalTitle": "Settings",
     "save": "Save"

--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -16,13 +16,7 @@
     "deleteAll": "Delete All Images",
     "deleteAllConfirm": "Are you sure you want to delete all images?",
     "deleteConfirm": "Are you sure you want to delete this image?",
-    "deleteCurrent": "Delete Current Image",
-    "task": {
-      "actions": {
-        "download": "Download",
-        "info": "Image Details"
-      }
-    }
+    "deleteCurrent": "Delete Current Image"
   },
   "input": {
     "placeholder": "Enter Midjourney prompt word...",
@@ -35,11 +29,11 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "baseUrl": {
-        "title": "Midjourney API Proxy Address"
-      },
       "apiSecret": {
         "title": "Midjourney API Proxy Secret"
+      },
+      "baseUrl": {
+        "title": "Midjourney API Proxy Address"
       },
       "description": "Please refer to <1>midjourney-proxy</1> for deploying the server and then use"
     },
@@ -48,6 +42,8 @@
   },
   "task": {
     "actions": {
+      "download": "Download",
+      "info": "Image Details",
       "reroll": "Reroll",
       "upscale": "Upscale",
       "variant": "Diversify"

--- a/locales/es-ES/common.json
+++ b/locales/es-ES/common.json
@@ -16,13 +16,7 @@
     "deleteAll": "Eliminar todas las imágenes",
     "deleteAllConfirm": "¿Estás seguro de que quieres eliminar todas las imágenes?",
     "deleteConfirm": "¿Estás seguro de que quieres eliminar esta imagen?",
-    "deleteCurrent": "Eliminar imagen actual",
-    "task": {
-      "actions": {
-        "download": "Descargar",
-        "info": "Detalles de la imagen"
-      }
-    }
+    "deleteCurrent": "Eliminar imagen actual"
   },
   "input": {
     "placeholder": "Ingrese las palabras clave de Midjourney...",
@@ -35,14 +29,21 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Por favor consulta <1>midjourney-proxy</1> para desplegar el servidor y luego utilizarlo",
-      "title": "Dirección del proxy de la API de Midjourney"
+      "apiSecret": {
+        "title": "Secreto de la API de Midjourney"
+      },
+      "baseUrl": {
+        "title": "Dirección de proxy de la API de Midjourney"
+      },
+      "description": "Por favor consulta <1>midjourney-proxy</1> para desplegar el servidor y luego utilizarlo"
     },
     "modalTitle": "Configuración",
     "save": "Guardar"
   },
   "task": {
     "actions": {
+      "download": "Descargar",
+      "info": "Detalles de la imagen",
       "reroll": "Volver a generar",
       "upscale": "Mejorar la calidad",
       "variant": "Variar"

--- a/locales/fr-FR/common.json
+++ b/locales/fr-FR/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Veuillez consulter <1>midjourney-proxy</1> pour déployer le service côté serveur avant utilisation",
-      "title": "Adresse du proxy Midjourney API"
+      "apiSecret": {
+        "title": "Secret du proxy API Midjourney"
+      },
+      "baseUrl": {
+        "title": "Adresse du proxy API Midjourney"
+      },
+      "description": "Veuillez consulter <1>midjourney-proxy</1> pour déployer le service côté serveur avant utilisation"
     },
     "modalTitle": "Paramètres",
     "save": "Enregistrer"

--- a/locales/it-IT/common.json
+++ b/locales/it-IT/common.json
@@ -35,8 +35,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Si prega di fare riferimento a <1>midjourney-proxy</1> per utilizzare il servizio lato server",
-      "title": "Indirizzo del proxy API di Midjourney"
+      "apiSecret": {
+        "title": "Segreto del proxy API di Midjourney"
+      },
+      "baseUrl": {
+        "title": "Indirizzo del proxy API di Midjourney"
+      },
+      "description": "Si prega di fare riferimento a <1>midjourney-proxy</1> per utilizzare il servizio lato server"
     },
     "modalTitle": "Impostazioni",
     "save": "Salva"

--- a/locales/ja-JP/common.json
+++ b/locales/ja-JP/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "サーバーをデプロイした後、<1>midjourney-proxy</1> を参照して使用してください",
-      "title": "Midjourney APIプロキシアドレス"
+      "apiSecret": {
+        "title": "Midjourney API プロキシシークレット"
+      },
+      "baseUrl": {
+        "title": "Midjourney API プロキシアドレス"
+      },
+      "description": "サーバーをデプロイした後、<1>midjourney-proxy</1> を参照して使用してください"
     },
     "modalTitle": "設定",
     "save": "保存"

--- a/locales/ko-KR/common.json
+++ b/locales/ko-KR/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "<1>midjourney-proxy</1>를 참조하여 서버를 배포한 후 사용하세요",
-      "title": "Midjourney API 프록시 주소"
+      "apiSecret": {
+        "title": "Midjourney API 프록시 비밀번호"
+      },
+      "baseUrl": {
+        "title": "Midjourney API 프록시 주소"
+      },
+      "description": "<1>midjourney-proxy</1>를 참조하여 서버를 배포한 후 사용하세요"
     },
     "modalTitle": "설정",
     "save": "저장"

--- a/locales/nl-NL/common.json
+++ b/locales/nl-NL/common.json
@@ -16,13 +16,7 @@
     "deleteAll": "Alle afbeeldingen verwijderen",
     "deleteAllConfirm": "Weet je zeker dat je alle afbeeldingen wilt verwijderen?",
     "deleteConfirm": "Weet je zeker dat je deze afbeelding wilt verwijderen?",
-    "deleteCurrent": "Huidige afbeelding verwijderen",
-    "task": {
-      "actions": {
-        "download": "Downloaden",
-        "info": "Afbeeldingsdetails"
-      }
-    }
+    "deleteCurrent": "Huidige afbeelding verwijderen"
   },
   "input": {
     "placeholder": "Voer een suggestiewoord voor Midjourney in...",
@@ -35,14 +29,21 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Raadpleeg <1>midjourney-proxy</1> voor het implementeren van de serverzijde service",
-      "title": "Adres van de Midjourney API-proxy"
+      "apiSecret": {
+        "title": "Midjourney API Proxy-geheim"
+      },
+      "baseUrl": {
+        "title": "Midjourney API Proxy-adres"
+      },
+      "description": "Raadpleeg <1>midjourney-proxy</1> voor het implementeren van de serverzijde service"
     },
     "modalTitle": "Instellingen",
     "save": "Opslaan"
   },
   "task": {
     "actions": {
+      "download": "Downloaden",
+      "info": "Afbeeldingsdetails",
       "reroll": "Opnieuw genereren",
       "upscale": "Opschalen",
       "variant": "Diversifiëren"

--- a/locales/pl-PL/common.json
+++ b/locales/pl-PL/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Proszę skonsultować się z <1>midjourney-proxy</1> w celu skonfigurowania serwera",
-      "title": "Adres proxy API Midjourney"
+      "apiSecret": {
+        "title": "Sekret proxy Midjourney API"
+      },
+      "baseUrl": {
+        "title": "Adres proxy Midjourney API"
+      },
+      "description": "Proszę skonsultować się z <1>midjourney-proxy</1> w celu skonfigurowania serwera"
     },
     "modalTitle": "Ustawienia",
     "save": "Zapisz"

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -16,13 +16,7 @@
     "deleteAll": "Excluir todas as imagens",
     "deleteAllConfirm": "Tem certeza de que deseja excluir todas as imagens?",
     "deleteConfirm": "Tem certeza de que deseja excluir esta imagem?",
-    "deleteCurrent": "Excluir imagem atual",
-    "task": {
-      "actions": {
-        "download": "Baixar",
-        "info": "Detalhes da imagem"
-      }
-    }
+    "deleteCurrent": "Excluir imagem atual"
   },
   "input": {
     "placeholder": "Digite as palavras-chave do Midjourney...",
@@ -35,14 +29,21 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Consulte <1>midjourney-proxy</1> para implantar o servidor e usá-lo",
-      "title": "Endereço do proxy da API Midjourney"
+      "apiSecret": {
+        "title": "Segredo do Proxy da API Midjourney"
+      },
+      "baseUrl": {
+        "title": "Endereço do Proxy da API Midjourney"
+      },
+      "description": "Consulte <1>midjourney-proxy</1> para implantar o servidor e usá-lo"
     },
     "modalTitle": "Configurações",
     "save": "Salvar"
   },
   "task": {
     "actions": {
+      "download": "Baixar",
+      "info": "Detalhes da Imagem",
       "reroll": "Rolar novamente",
       "upscale": "Aprimorar",
       "variant": "Variar"

--- a/locales/ru-RU/common.json
+++ b/locales/ru-RU/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Пожалуйста, укажите адрес сервера для использования <1>midjourney-proxy</1>",
-      "title": "Адрес прокси Midjourney API"
+      "apiSecret": {
+        "title": "Секрет прокси Midjourney API"
+      },
+      "baseUrl": {
+        "title": "Адрес прокси Midjourney API"
+      },
+      "description": "Пожалуйста, укажите адрес сервера для использования <1>midjourney-proxy</1>"
     },
     "modalTitle": "Настройки",
     "save": "Сохранить"

--- a/locales/tr-TR/common.json
+++ b/locales/tr-TR/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Lütfen <1>midjourney-proxy</1> bağlantısına giderek sunucu tarafını kurduktan sonra kullanın",
-      "title": "Midjourney API Vekil Adresi"
+      "apiSecret": {
+        "title": "Midjourney API Proxy Gizlisi"
+      },
+      "baseUrl": {
+        "title": "Midjourney API Proxy Adresi"
+      },
+      "description": "Lütfen <1>midjourney-proxy</1> bağlantısına giderek sunucu tarafını kurduktan sonra kullanın"
     },
     "modalTitle": "Ayarlar",
     "save": "Kaydet"

--- a/locales/vi-VN/common.json
+++ b/locales/vi-VN/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "Vui lòng tham khảo <1>midjourney-proxy</1> để triển khai dịch vụ máy chủ trước khi sử dụng",
-      "title": "Địa chỉ proxy API Midjourney"
+      "apiSecret": {
+        "title": "Bí mật proxy API Midjourney"
+      },
+      "baseUrl": {
+        "title": "Địa chỉ proxy API Midjourney"
+      },
+      "description": "Vui lòng tham khảo <1>midjourney-proxy</1> để triển khai dịch vụ máy chủ trước khi sử dụng"
     },
     "modalTitle": "Cài đặt",
     "save": "Lưu"

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -29,7 +29,12 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "title": "Midjourney API 代理地址",
+      "baseUrl": {
+        "title": "Midjourney API 代理地址"
+      },
+      "apiSecret": {
+        "title": "Midjourney API 代理 Secret"
+      },
       "description": "请参考 <1>midjourney-proxy</1> 部署好服务端后使用"
     },
     "modalTitle": "设置",

--- a/locales/zh-TW/common.json
+++ b/locales/zh-TW/common.json
@@ -29,8 +29,13 @@
   },
   "settings": {
     "MidjourneyAPIProxy": {
-      "description": "請參考 <1>midjourney-proxy</1> 部署好服務端後使用",
-      "title": "Midjourney API 代理地址"
+      "apiSecret": {
+        "title": "Midjourney API 代理密鑰"
+      },
+      "baseUrl": {
+        "title": "Midjourney API 代理位址"
+      },
+      "description": "請參考 <1>midjourney-proxy</1> 部署好服務端後使用"
     },
     "modalTitle": "設定",
     "save": "保存"

--- a/public/manifest-dev.json
+++ b/public/manifest-dev.json
@@ -29,8 +29,15 @@
     "type": "object",
     "properties": {
       "MIDJOURNEY_PROXY_URL": {
+        "title": "Midjourney Proxy URL",
         "type": "string",
-        "description": "please add url of deployment of [midjourney-proxy](https://github.com/novicezk/midjourney-proxy)"
+        "description": "Please add URL of deployment of [midjourney-proxy](https://github.com/novicezk/midjourney-proxy)"
+      },
+      "MIDJOURNEY_PROXY_API_SECRET": {
+        "title": "Midjourney Proxy API Secret",
+        "type": "string",
+        "description": "Please add API secret of [midjourney-proxy](https://github.com/novicezk/midjourney-proxy)",
+        "format": "password"
       }
     },
     "required": ["MIDJOURNEY_PROXY_URL"]

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,8 +29,15 @@
     "type": "object",
     "properties": {
       "MIDJOURNEY_PROXY_URL": {
+        "title": "Midjourney Proxy URL",
         "type": "string",
-        "description": "please add url of deployment of [midjourney-proxy](https://github.com/novicezk/midjourney-proxy)"
+        "description": "Please add URL of deployment of [midjourney-proxy](https://github.com/novicezk/midjourney-proxy)"
+      },
+      "MIDJOURNEY_PROXY_API_SECRET": {
+        "title": "Midjourney Proxy API Secret",
+        "type": "string",
+        "description": "Please add API secret of [midjourney-proxy](https://github.com/novicezk/midjourney-proxy)",
+        "format": "password"
       }
     },
     "required": ["MIDJOURNEY_PROXY_URL"]

--- a/src/app/api/midjourney/route.ts
+++ b/src/app/api/midjourney/route.ts
@@ -4,7 +4,7 @@ import { getServerConfig } from '@/config/server';
 
 export const runtime = 'edge';
 
-const { MIDJOURNEY_PROXY_URL: base } = getServerConfig();
+const { MIDJOURNEY_PROXY_URL: base, MIDJOURNEY_PROXY_API_SECRET: apiSecret } = getServerConfig();
 
 const getBase = (req: Request) => {
   const userDefineBaseUrl = req.headers.get('X-Midjourney-Proxy-Url');
@@ -12,8 +12,15 @@ const getBase = (req: Request) => {
   return userDefineBaseUrl || base;
 };
 
+const getAPISecret = (req: Request) => {
+  const userDefinedAPISecret = req.headers.get('X-Midjourney-Proxy-Api-Secret');
+
+  return userDefinedAPISecret || apiSecret;
+};
+
 export const POST = async (req: Request) => {
   const baseUrl = getBase(req);
+  const apiSecret = getAPISecret(req);
 
   if (!baseUrl) return new Response(JSON.stringify({ type: 'NO_BASE_URL' }), { status: 400 });
 
@@ -21,19 +28,36 @@ export const POST = async (req: Request) => {
 
   const body = await req.text();
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (apiSecret) {
+    headers['Mj-Api-Secret'] = apiSecret;
+  }
+
   return fetch(urlJoin(baseUrl, path), {
     body,
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     method: 'POST',
   });
 };
 
 export const GET = async (req: Request) => {
   const baseUrl = getBase(req);
+  const apiSecret = getAPISecret(req);
 
   if (!baseUrl) return new Response(JSON.stringify({ type: 'NO_BASE_URL' }), { status: 400 });
 
   const path = new URL(req.url).searchParams.get('path')!;
 
-  return fetch(urlJoin(baseUrl, path), { headers: { 'Content-Type': 'application/json' } });
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (apiSecret) {
+    headers['Mj-Api-Secret'] = apiSecret;
+  }
+
+  return fetch(urlJoin(baseUrl, path), {
+    headers,
+  });
 };

--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -5,6 +5,7 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       MIDJOURNEY_PROXY_URL?: string;
+      MIDJOURNEY_PROXY_API_SECRET?: string;
       METADATA_BASE_URL?: string;
 
       IMGUR_CLIENT_ID?: string;
@@ -23,6 +24,7 @@ export const getServerConfig = () => {
 
   return {
     MIDJOURNEY_PROXY_URL: process.env.MIDJOURNEY_PROXY_URL,
+    MIDJOURNEY_PROXY_API_SECRET: process.env.MIDJOURNEY_PROXY_API_SECRET,
 
     METADATA_BASE_URL: process.env.METADATA_BASE_URL,
 

--- a/src/features/Settings.tsx
+++ b/src/features/Settings.tsx
@@ -12,9 +12,10 @@ import { settingsSelectors } from '@/store/global/selectors';
 
 const Settings = memo(() => {
   const { t } = useTranslation('common');
-  const [isSettingsModalOpen, proxyURL, updateSettings] = useGlobalStore((s) => [
+  const [isSettingsModalOpen, proxyURL, proxyAPISecret, updateSettings] = useGlobalStore((s) => [
     s.isSettingsModalOpen,
     settingsSelectors.proxyURL(s),
+    settingsSelectors.proxyAPISecret(s),
     s.updateSettings,
   ]);
 
@@ -72,13 +73,21 @@ const Settings = memo(() => {
             />
           )}
           <Flexbox gap={12}>
-            <div>{t('settings.MidjourneyAPIProxy.title')}</div>
+            <div>{t('settings.MidjourneyAPIProxy.baseUrl.title')}</div>
             <Input
               onChange={(e) => {
                 updateSettings({ MIDJOURNEY_PROXY_URL: e.target.value });
               }}
               placeholder={'https://your-midjourney-proxy'}
               value={proxyURL}
+            />
+            <div>{t('settings.MidjourneyAPIProxy.apiSecret.title')}</div>
+            <Input
+              onChange={(e) => {
+                updateSettings({ MIDJOURNEY_PROXY_API_SECRET: e.target.value });
+              }}
+              placeholder={'your-midjourney-api-secret'}
+              value={proxyAPISecret}
             />
             <Typography.Text type={'secondary'}>
               <Trans i18nKey={'settings.MidjourneyAPIProxy.description'} ns={'common'}>

--- a/src/features/Settings.tsx
+++ b/src/features/Settings.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Alert, Icon, Input, Modal } from '@lobehub/ui';
-import { Button, Typography } from 'antd';
+import { ActionIcon, Alert, Icon, Modal } from '@lobehub/ui';
+import { Button, Input, Typography } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { LucideSettings, Save } from 'lucide-react';
 import Link from 'next/link';
@@ -82,7 +82,7 @@ const Settings = memo(() => {
               value={proxyURL}
             />
             <div>{t('settings.MidjourneyAPIProxy.apiSecret.title')}</div>
-            <Input
+            <Input.Password
               onChange={(e) => {
                 updateSettings({ MIDJOURNEY_PROXY_API_SECRET: e.target.value });
               }}

--- a/src/services/midjourney.ts
+++ b/src/services/midjourney.ts
@@ -65,6 +65,8 @@ class MidjourneyService {
         body: data ? JSON.stringify(data) : undefined,
         headers: {
           'Content-Type': 'application/json',
+          'X-Midjourney-Proxy-Api-Secret':
+            useGlobalStore.getState().settings.MIDJOURNEY_PROXY_API_SECRET || '',
           'X-Midjourney-Proxy-Url': useGlobalStore.getState().settings.MIDJOURNEY_PROXY_URL || '',
         },
         method,

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -1,6 +1,7 @@
 import { LocaleMode } from '@/types/locale';
 
 export interface AppSettings {
+  MIDJOURNEY_PROXY_API_SECRET?: string;
   MIDJOURNEY_PROXY_URL?: string;
 }
 

--- a/src/store/global/selectors.ts
+++ b/src/store/global/selectors.ts
@@ -1,7 +1,9 @@
 import { SettingsStore } from './store';
 
+export const proxyAPISecret = (s: SettingsStore) => s.settings.MIDJOURNEY_PROXY_API_SECRET;
 export const proxyURL = (s: SettingsStore) => s.settings.MIDJOURNEY_PROXY_URL;
 
 export const settingsSelectors = {
+  proxyAPISecret,
   proxyURL,
 };

--- a/src/store/midjourney/initialState.ts
+++ b/src/store/midjourney/initialState.ts
@@ -1,6 +1,7 @@
 import { MidjourneyTask } from '@/types/task';
 
 export interface AppSettings {
+  MIDJOURNEY_PROXY_API_SECRET?: string;
   MIDJOURNEY_PROXY_URL?: string;
 }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

This PR adds support for configuring the API secret to be passed as `Mj-Api-Secret` header to midjourney-proxy(-plus).

Users have the flexibility to set the API secret in two ways: on the server side, it can be specified through the `MIDJOURNEY_PROXY_API_SECRET` environment variable; on the client side, it can be configured via the LobeChat plugin settings or through the settings dialog available in the standalone web UI, similar to the process for configuring the proxy URL.

Closes #14, closes #24, closes #25

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

I found that LobeChat seems to have a small bug that will prevent the Midjourney plugin from working after this PR is merged, and have proposed a PR https://github.com/lobehub/lobe-chat/pull/1991 for that. Please review that PR before this. Thanks!